### PR TITLE
make it possible to specify window bits, and possible to specify parameters from zstr::istream/ostream

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -7,7 +7,7 @@ SHELL := /bin/bash
 all: test-strict_fstream ztxtpipe zpipe zc
 
 %: %.cpp
-	g++ -std=c++11 -O0 -g3 -ggdb -fno-eliminate-unused-debug-types -Wall -Wextra -pedantic -I../src -o $@ $^ -lz
+	g++ -std=c++14 -O0 -g3 -ggdb -fno-eliminate-unused-debug-types -Wall -Wextra -pedantic -I../src -o $@ $^ -lz
 
 test: ztxtpipe zpipe zc
 	diff -q ztxtpipe.cpp <(./ztxtpipe <ztxtpipe.cpp)

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -7,7 +7,7 @@ SHELL := /bin/bash
 all: test-strict_fstream ztxtpipe zpipe zc
 
 %: %.cpp
-	g++ -std=c++14 -O0 -g3 -ggdb -fno-eliminate-unused-debug-types -Wall -Wextra -pedantic -I../src -o $@ $^ -lz
+	g++ -std=c++11 -O0 -g3 -ggdb -fno-eliminate-unused-debug-types -Wall -Wextra -pedantic -I../src -o $@ $^ -lz
 
 test: ztxtpipe zpipe zc
 	diff -q ztxtpipe.cpp <(./ztxtpipe <ztxtpipe.cpp)

--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -125,7 +125,7 @@ struct static_method_holder
             is_p->peek();
             peek_failed = is_p->fail();
         }
-        catch (const std::ios_base::failure &e) {}
+        catch (const std::ios_base::failure &) {}
         if (peek_failed)
         {
             throw Exception(std::string("strict_fstream: open('")

--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -16,11 +16,18 @@
 namespace strict_fstream
 {
 
+// Help people out a bit, it seems like this is a common recommenation since
+// musl breaks all over the place.
+#if defined(__NEED_size_t) && !defined(__MUSL__)
+#warning "It seems to be recommended to patch in a define for __MUSL__ if you use musl globally: https://www.openwall.com/lists/musl/2013/02/10/5"
+#define __MUSL__
+#endif
+
 // Workaround for broken musl implementation
 // Since musl insists that they are perfectly compatible, ironically enough,
-// they don't have a __musl__ or similar. But __NEED_size_t is defined in their
+// they don't officially have a __musl__ or similar. But __NEED_size_t is defined in their
 // relevant header (and not in working implementations), so we can use that.
-#ifdef __NEED_size_t
+#ifdef __MUSL__
 #define BROKEN_GNU_STRERROR_R
 #warning "Working around broken strerror_r() implementation in musl, remove when musl is fixed"
 #endif

--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -37,7 +37,7 @@ static std::string strerror()
         buff = "Unknown error";
     }
     return buff;
-#elif (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__APPLE__) || defined(BROKEN_GNU_STRERROR_R)) && ! _GNU_SOURCE
+#elif ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__APPLE__)) && ! _GNU_SOURCE) || defined(BROKEN_GNU_STRERROR_R)
 // XSI-compliant strerror_r()
     if (strerror_r(errno, buff.data(), buff.size()) == 0) {
         buff.resize(buff.find('\0'));

--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -20,7 +20,7 @@ namespace strict_fstream
 /// and POSIX signature found in MUSL on Alpine (2)
 /// Ref 1: http://stackoverflow.com/a/901316/717706
 /// Ref 2: http://stackoverflow.com/a/41956165
-static inline char* strerror_r_compat(int result, char* buffer, int err)
+static char* strerror_r_compat(int result, char* buffer, int err)
 {
     if (result)
     {
@@ -29,7 +29,7 @@ static inline char* strerror_r_compat(int result, char* buffer, int err)
     return buffer;
 }
 
-static inline char* strerror_r_compat(char* result, char*, int)
+static char* strerror_r_compat(char* result, char*, int)
 {
     return result;
 }

--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -39,10 +39,7 @@ static std::string strerror()
     std::string tmp(p, std::strlen(p));
     std::swap(buff, tmp);
 #endif
-    if(buff.find('\0') != std::string::npos)
-    {
-        buff.resize(buff.find('\0'));
-    }
+    buff.resize(buff.find('\0'));
     return buff;
 }
 

--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -35,7 +35,7 @@ static std::string strerror()
     }
 #else
 // GNU-specific strerror_r()
-    auto p = strerror_r(errno, &buff[0], buff.size());
+    char * p = strerror_r(errno, &buff[0], buff.size());
     std::string tmp(p, std::strlen(p));
     std::swap(buff, tmp);
 #endif

--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -16,6 +16,15 @@
 namespace strict_fstream
 {
 
+// Workaround for broken musl implementation
+// Since musl insists that they are perfectly compatible, ironically enough,
+// they don't have a __musl__ or similar. But __NEED_size_t is defined in their
+// relevant header (and not in working implementations), so we can use that.
+#ifdef __NEED_size_t
+#define BROKEN_GNU_STRERROR_R
+#warning "Working around broken strerror_r() implementation in musl, remove when musl is fixed"
+#endif
+
 /// Overload of error-reporting function, to enable use with VS.
 /// Ref: http://stackoverflow.com/a/901316/717706
 static std::string strerror()
@@ -28,7 +37,7 @@ static std::string strerror()
         buff = "Unknown error";
     }
     return buff;
-#elif (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__APPLE__)) && ! _GNU_SOURCE
+#elif (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__APPLE__) || defined(BROKEN_GNU_STRERROR_R)) && ! _GNU_SOURCE
 // XSI-compliant strerror_r()
     if (strerror_r(errno, buff.data(), buff.size()) == 0) {
         buff.resize(buff.find('\0'));

--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <cstring>
 #include <string>
+#include <vector>
 
 /**
  * This namespace defines wrappers for std::ifstream, std::ofstream, and
@@ -33,22 +34,28 @@ namespace strict_fstream
 
 // Non-gnu variants of strerror_* don't necessarily null-terminate if
 // truncating, so we have to do things manually.
-inline std::string &trim_to_null(std::string &buff)
+inline std::string trim_to_null(const std::vector<char> &buff)
 {
-    const std::string::size_type pos = buff.find('\0');
+    std::string ret(buff.begin(), buff.end());
+
+    const std::string::size_type pos = ret.find('\0');
     if (pos == std::string::npos) {
-        buff += " [...]"; // it has been truncated
+        ret += " [...]"; // it has been truncated
     } else {
-        buff.resize(pos);
+        ret.resize(pos);
     }
-    return buff;
+    return ret;
 }
 
-/// Overload of error-reporting function, to enable use with VS.
-/// Ref: http://stackoverflow.com/a/901316/717706
+/// Overload of error-reporting function, to enable use with VS and non-GNU
+/// POSIX libc's
+/// Ref:
+///   - http://stackoverflow.com/a/901316/717706
 static std::string strerror()
 {
-    std::string buff(256, '\0');
+    // Can't use std::string since we're pre-C++17
+    std::vector<char> buff(256, '\0');
+
 #ifdef _WIN32
     // Since strerror_s might set errno itself, we need to store it.
     const int err_num = errno;

--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -27,7 +27,7 @@ static std::string strerror()
     {
         buff = "Unknown error";
     }
-#elif (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE
+#elif (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__APPLE__)) && ! _GNU_SOURCE
 // XSI-compliant strerror_r()
     if (strerror_r(errno, &buff[0], buff.size()) != 0)
     {

--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -21,26 +21,27 @@ namespace strict_fstream
 /// Ref: http://stackoverflow.com/a/901316/717706
 static std::string strerror()
 {
-    std::string buff(80, '\0');
+    std::string buff(256, '\0');
 #ifdef _WIN32
-    if (strerror_s(&buff[0], buff.size(), errno) != 0)
-    {
+    if (strerror_s(buff.data(), buff.size(), errno) == 0) {
+        buff.resize(buff.find('\0'));
+    } else {
         buff = "Unknown error";
     }
+    return buff;
 #elif (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || defined(__APPLE__)) && ! _GNU_SOURCE
 // XSI-compliant strerror_r()
-    if (strerror_r(errno, &buff[0], buff.size()) != 0)
-    {
+    if (strerror_r(errno, buff.data(), buff.size()) == 0) {
+        buff.resize(buff.find('\0'));
+    } else {
         buff = "Unknown error";
     }
+    return buff;
 #else
 // GNU-specific strerror_r()
     char * p = strerror_r(errno, &buff[0], buff.size());
-    std::string tmp(p, std::strlen(p));
-    std::swap(buff, tmp);
+    return std::string(p, std::strlen(p));
 #endif
-    buff.resize(buff.find('\0'));
-    return buff;
 }
 
 /// Exception class thrown by failed operations.

--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -1,5 +1,4 @@
-#ifndef __STRICT_FSTREAM_HPP
-#define __STRICT_FSTREAM_HPP
+#pragma once
 
 #include <cassert>
 #include <fstream>
@@ -200,4 +199,3 @@ public:
 
 } // namespace strict_fstream
 
-#endif

--- a/src/zstr.hpp
+++ b/src/zstr.hpp
@@ -213,6 +213,10 @@ public:
                     in_buff_end = in_buff_start + zstrm_p->avail_in;
                     out_buff_free_start = reinterpret_cast< decltype(out_buff_free_start) >(zstrm_p->next_out);
                     assert(out_buff_free_start + zstrm_p->avail_out == out_buff.get() + buff_size);
+
+                    if (ret == Z_STREAM_END) {
+                        break;
+                    }
                 }
             } while (out_buff_free_start == out_buff.get());
             // 2 exit conditions:

--- a/src/zstr.hpp
+++ b/src/zstr.hpp
@@ -13,7 +13,7 @@
 #include <fstream>
 #include <sstream>
 #include <zlib.h>
-#include "strict_fstream.hpp"
+#include <strict_fstream.hpp>
 
 namespace zstr
 {

--- a/src/zstr.hpp
+++ b/src/zstr.hpp
@@ -6,8 +6,7 @@
 // Reference:
 // http://stackoverflow.com/questions/14086417/how-to-write-custom-input-stream-in-c
 
-#ifndef __ZSTR_HPP
-#define __ZSTR_HPP
+#pragma once
 
 #include <cassert>
 #include <fstream>
@@ -437,4 +436,3 @@ public:
 
 } // namespace zstr
 
-#endif

--- a/src/zstr.hpp
+++ b/src/zstr.hpp
@@ -203,9 +203,9 @@ public:
                     // run inflate() on input
                     if (! zstrm_p) zstrm_p = std::make_unique<detail::z_stream_wrapper>(true, Z_DEFAULT_COMPRESSION, window_bits);
                     zstrm_p->next_in = reinterpret_cast< decltype(zstrm_p->next_in) >(in_buff_start);
-                    zstrm_p->avail_in = in_buff_end - in_buff_start;
+                    zstrm_p->avail_in = uint32_t(in_buff_end - in_buff_start);
                     zstrm_p->next_out = reinterpret_cast< decltype(zstrm_p->next_out) >(out_buff_free_start);
-                    zstrm_p->avail_out = (out_buff.get() + buff_size) - out_buff_free_start;
+                    zstrm_p->avail_out = uint32_t((out_buff.get() + buff_size) - out_buff_free_start);
                     int ret = inflate(zstrm_p.get(), Z_NO_FLUSH);
                     // process return code
                     if (ret != Z_OK && ret != Z_STREAM_END) throw Exception(zstrm_p.get(), ret);
@@ -265,7 +265,7 @@ public:
         while (true)
         {
             zstrm_p->next_out = reinterpret_cast< decltype(zstrm_p->next_out) >(out_buff.get());
-            zstrm_p->avail_out = buff_size;
+            zstrm_p->avail_out = uint32_t(buff_size);
             int ret = deflate(zstrm_p.get(), flush);
             if (ret != Z_OK && ret != Z_STREAM_END && ret != Z_BUF_ERROR) {
                 failed = true;
@@ -302,7 +302,7 @@ public:
     std::streambuf::int_type overflow(std::streambuf::int_type c = traits_type::eof()) override
     {
         zstrm_p->next_in = reinterpret_cast< decltype(zstrm_p->next_in) >(pbase());
-        zstrm_p->avail_in = pptr() - pbase();
+        zstrm_p->avail_in = uint32_t(pptr() - pbase());
         while (zstrm_p->avail_in > 0)
         {
             int r = deflate_loop(Z_NO_FLUSH);
@@ -313,7 +313,7 @@ public:
             }
         }
         setp(in_buff.get(), in_buff.get() + buff_size);
-        return traits_type::eq_int_type(c, traits_type::eof()) ? traits_type::eof() : sputc(c);
+        return traits_type::eq_int_type(c, traits_type::eof()) ? traits_type::eof() : sputc(char_type(c));
     }
     int sync() override
     {

--- a/src/zstr.hpp
+++ b/src/zstr.hpp
@@ -303,9 +303,9 @@ public:
         // close the ofstream with an explicit call to close(), and do not rely
         // on the implicit call in the destructor.
         //
-        if (!failed) {
+        if (!failed) try {
             sync();
-        }
+        } catch (...) {}
     }
     std::streambuf::int_type overflow(std::streambuf::int_type c = traits_type::eof()) override
     {

--- a/src/zstr.hpp
+++ b/src/zstr.hpp
@@ -162,8 +162,13 @@ public:
         {
             // pointers for free region in output buffer
             char * out_buff_free_start = out_buff.get();
+            int tries = 0;
             do
             {
+                if (++tries > 1000) {
+                    throw std::ios_base::failure("Failed to fill buffer after 1000 tries");
+                }
+
                 // read more input if none available
                 if (in_buff_start == in_buff_end)
                 {

--- a/src/zstr.hpp
+++ b/src/zstr.hpp
@@ -250,7 +250,7 @@ public:
             zstrm_p->next_out = reinterpret_cast< decltype(zstrm_p->next_out) >(out_buff.get());
             zstrm_p->avail_out = buff_size;
             int ret = deflate(zstrm_p.get(), flush);
-            if (ret != Z_OK && ret != Z_STREAM_END) {
+            if (ret != Z_OK && ret != Z_STREAM_END && ret != Z_BUF_ERROR) {
                 failed = true;
                 throw Exception(zstrm_p.get(), ret);
             }

--- a/src/zstr.hpp
+++ b/src/zstr.hpp
@@ -141,9 +141,7 @@ public:
     }
 
     istreambuf(const istreambuf &) = delete;
-    istreambuf(istreambuf &&) = default;
     istreambuf & operator = (const istreambuf &) = delete;
-    istreambuf & operator = (istreambuf &&) = default;
 
     pos_type seekoff(off_type off, std::ios_base::seekdir dir,
                      std::ios_base::openmode which) override
@@ -260,9 +258,7 @@ public:
     }
 
     ostreambuf(const ostreambuf &) = delete;
-    ostreambuf(ostreambuf &&) = default;
     ostreambuf & operator = (const ostreambuf &) = delete;
-    ostreambuf & operator = (ostreambuf &&) = default;
 
     int deflate_loop(int flush)
     {

--- a/src/zstr.hpp
+++ b/src/zstr.hpp
@@ -424,6 +424,11 @@ public:
     {
         exceptions(std::ios_base::badbit);
     }
+    ofstream& flush() {
+        std::ostream::flush();
+        _fs.flush();
+        return *this;
+    }
     virtual ~ofstream()
     {
         if (rdbuf()) delete rdbuf();

--- a/src/zstr.hpp
+++ b/src/zstr.hpp
@@ -16,6 +16,10 @@
 #include <memory>
 #include <iostream>
 
+#if __cplusplus == 201103L
+#include <zstr_make_unique_polyfill.h>
+#endif
+
 namespace zstr
 {
 

--- a/src/zstr.hpp
+++ b/src/zstr.hpp
@@ -220,7 +220,8 @@ public:
                     assert(out_buff_free_start + zstrm_p->avail_out == out_buff.get() + buff_size);
 
                     if (ret == Z_STREAM_END) {
-                        break;
+                        // if stream ended, deallocate inflator
+                        zstrm_p.reset();
                     }
                 }
             } while (out_buff_free_start == out_buff.get());

--- a/src/zstr.hpp
+++ b/src/zstr.hpp
@@ -335,6 +335,8 @@ private:
     std::size_t buff_size;
     bool failed = false;
 
+public:
+    static const std::size_t default_buff_size = (std::size_t)1 << 20;
 }; // class ostreambuf
 
 class istream
@@ -415,9 +417,10 @@ class ofstream
       public std::ostream
 {
 public:
-    explicit ofstream(const std::string& filename, std::ios_base::openmode mode = std::ios_base::out)
+    explicit ofstream(const std::string& filename, std::ios_base::openmode mode = std::ios_base::out,
+                      int level = Z_DEFAULT_COMPRESSION)
         : detail::strict_fstream_holder< strict_fstream::ofstream >(filename, mode | std::ios_base::binary),
-          std::ostream(new ostreambuf(_fs.rdbuf()))
+          std::ostream(new ostreambuf(_fs.rdbuf(), ostreambuf::default_buff_size, level))
     {
         exceptions(std::ios_base::badbit);
     }

--- a/src/zstr_make_unique_polyfill.h
+++ b/src/zstr_make_unique_polyfill.h
@@ -1,0 +1,86 @@
+/*
+ * This program source code file is part of KiCad, a free EDA CAD application.
+ *
+ * Copyright (C) 2017 KiCad Developers, see AUTHORS.txt for contributors.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, you may find one here:
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ * or you may search the http://www.gnu.org website for the version 2 license,
+ * or you may write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+ */
+
+/**
+ * @file make_unique.h
+ * @brief Implementation of std::make_unique for pre C++14 compilation
+ * environments
+ */
+
+#pragma once
+
+// Define std::make_unique if the compiler is C++11, but not C++14
+// (which provides this itself)
+// When C++14 support is a KiCad pre-requisite, this entire file
+// can be removed.
+#if __cplusplus == 201103L
+
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+// It's a bit naughty to add things to std::, but the point is to
+// "polyfill" this function in only if std:: doesn't have it
+//
+// This implementation is the one proposed by Stephan T. Lavavej
+// in N3656: https://isocpp.org/files/papers/N3656.txt
+// This is more or less exactly how it is implemented in GCC (e.g. 6.3.1)
+// when C++14 is enabled.
+namespace std
+{
+    template<class T> struct _Unique_if {
+        typedef unique_ptr<T> _Single_object;
+    };
+
+    template<class T> struct _Unique_if<T[]> {
+        typedef unique_ptr<T[]> _Unknown_bound;
+    };
+
+    template<class T, size_t N> struct _Unique_if<T[N]> {
+        typedef void _Known_bound;
+    };
+
+    /// std::make_unique for single objects
+    template<class T, class... Args>
+        typename _Unique_if<T>::_Single_object
+        make_unique(Args&&... args) {
+            return unique_ptr<T>(new T(std::forward<Args>(args)...));
+        }
+
+    /// std::make_unique for arrays of unknown bound
+    template<class T>
+        typename _Unique_if<T>::_Unknown_bound
+        make_unique(size_t n) {
+            typedef typename remove_extent<T>::type U;
+            return unique_ptr<T>(new U[n]());
+        }
+
+    /// Disable std::make_unique for arrays of known bound
+    template<class T, class... Args>
+        typename _Unique_if<T>::_Known_bound
+        make_unique(Args&&...) = delete;
+}
+
+#endif // __cplusplus == 201103L
+


### PR DESCRIPTION
fwiw, added it because it's necessary for decompressing the age of empires (2) game files

the changes have been tested a lot in https://github.com/sandsmark/freeaoe/ and https://github.com/sandsmark/AGE via https://github.com/sandsmark/genieutils