### PR TITLE
Catch exceptions by const reference

### DIFF
--- a/examples/test-strict_fstream.cpp
+++ b/examples/test-strict_fstream.cpp
@@ -18,7 +18,7 @@ void test_open(const std::string& stream_class, const std::string& stream_type,
         s_p->open(filename, static_cast< std::ios_base::openmode >(mode));
         exception_thrown = false;
     }
-    catch (std::exception) {}
+    catch (const std::exception &) {}
     std::cout << stream_class << " " << stream_type << " " << (set_fail_bit? "failbit" : "nofailbit") << " "
               << strict_fstream::detail::static_method_holder::mode_to_string(
                   static_cast< std::ios_base::openmode >(mode))

--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -125,7 +125,7 @@ struct static_method_holder
             is_p->peek();
             peek_failed = is_p->fail();
         }
-        catch (std::ios_base::failure e) {}
+        catch (const std::ios_base::failure &e) {}
         if (peek_failed)
         {
             throw Exception(std::string("strict_fstream: open('")


### PR DESCRIPTION
This avoids the risk of slicing objects thrown as exceptions if they are
a subclass of the type we catch.