### PR TITLE
Catch std::ios_base::failure by reference

### DIFF
--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -125,7 +125,7 @@ struct static_method_holder
             is_p->peek();
             peek_failed = is_p->fail();
         }
-        catch (std::ios_base::failure e) {}
+        catch (const std::ios_base::failure& e) {}
         if (peek_failed)
         {
             throw Exception(std::string("strict_fstream: open('")


### PR DESCRIPTION
This eliminates the following G++ warning:

`zstr/src/strict_fstream.hpp:128:39: warning: catching polymorphic type ‘class std::ios_base::failure’ by value [-Wcatch-value=]`