### PR TITLE
Only trim buffer if there is a \0 in it

### DIFF
--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -39,7 +39,10 @@ static std::string strerror()
     std::string tmp(p, std::strlen(p));
     std::swap(buff, tmp);
 #endif
-    buff.resize(buff.find('\0'));
+    if(buff.find('\0') != std::string::npos)
+    {
+        buff.resize(buff.find('\0'));
+    }
     return buff;
 }
 


### PR DESCRIPTION
Fixes https://github.com/mateidavid/zstr/issues/20