### PR TITLE
Delete move constructors and assignment operators

### DIFF
--- a/src/zstr.hpp
+++ b/src/zstr.hpp
@@ -122,9 +122,7 @@ public:
     }
 
     istreambuf(const istreambuf &) = delete;
-    istreambuf(istreambuf &&) = default;
     istreambuf & operator = (const istreambuf &) = delete;
-    istreambuf & operator = (istreambuf &&) = default;
 
     virtual ~istreambuf()
     {
@@ -239,9 +237,7 @@ public:
     }
 
     ostreambuf(const ostreambuf &) = delete;
-    ostreambuf(ostreambuf &&) = default;
     ostreambuf & operator = (const ostreambuf &) = delete;
-    ostreambuf & operator = (ostreambuf &&) = default;
 
     int deflate_loop(int flush)
     {


### PR DESCRIPTION
Fixes https://github.com/mateidavid/zstr/issues/16

Copied from https://github.com/facebookincubator/profilo/commit/2955a06fb0d1f306b161db22199dc6898d6d74d8

Summary:
std::streambuf has an inaccessible move constructor and assignment
operator, which means any derived classes can't use the default ones.
See https://cplusplus.github.io/LWG/issue911 for why this is; derived
classes need to specialize how they handle moving and can't rely on the
default behavior. Consequently, the default declarations here have no
effect, and Clang 8 complains about them having no effect, so just get
rid of them. I submitted mateidavid/zstr#16
upstream to flag the issue as well, though that repository doesn't seem
particularly active.