### PR TITLE
strerror_r variant compatibility

### DIFF
--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -16,9 +16,24 @@
  */
 namespace strict_fstream
 {
+/// Overload of error-reporting function, to enable use with VS (1)
+/// and POSIX signature found in MUSL on Alpine (2)
+/// Ref 1: http://stackoverflow.com/a/901316/717706
+/// Ref 2: http://stackoverflow.com/a/41956165
+static char* strerror_r_compat(int result, char* buffer, int err)
+{
+    if (result)
+    {
+        sprintf(buffer, "Unknown error: %d", err);
+    }
+    return buffer;
+}
 
-/// Overload of error-reporting function, to enable use with VS.
-/// Ref: http://stackoverflow.com/a/901316/717706
+static char* strerror_r_compat(char* result, char*, int)
+{
+    return result;
+}
+
 static std::string strerror()
 {
     std::string buff(80, '\0');
@@ -27,15 +42,8 @@ static std::string strerror()
     {
         buff = "Unknown error";
     }
-#elif (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE
-// XSI-compliant strerror_r()
-    if (strerror_r(errno, &buff[0], buff.size()) != 0)
-    {
-        buff = "Unknown error";
-    }
 #else
-// GNU-specific strerror_r()
-    auto p = strerror_r(errno, &buff[0], buff.size());
+    auto p = strerror_r_compat(strerror_r(errno, &buff[0], buff.size()), &buff[0], errno);
     std::string tmp(p, std::strlen(p));
     std::swap(buff, tmp);
 #endif

--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -20,7 +20,7 @@ namespace strict_fstream
 /// and POSIX signature found in MUSL on Alpine (2)
 /// Ref 1: http://stackoverflow.com/a/901316/717706
 /// Ref 2: http://stackoverflow.com/a/41956165
-static char* strerror_r_compat(int result, char* buffer, int err)
+static inline char* strerror_r_compat(int result, char* buffer, int err)
 {
     if (result)
     {
@@ -29,7 +29,7 @@ static char* strerror_r_compat(int result, char* buffer, int err)
     return buffer;
 }
 
-static char* strerror_r_compat(char* result, char*, int)
+static inline char* strerror_r_compat(char* result, char*, int)
 {
     return result;
 }


### PR DESCRIPTION
This pull request fixes issues with the different variants of `strerror_r`.

Originally encountered this in Alpine Linux, which uses musl as their libc implementation. I was unable to compile due to a non-compliant implementation of `strerror_r`. 

The fix wraps the call to `strerror_r` with an overloaded function that deals with the non-compliant return type. This eliminates the preprocessor macros for XSI/GNU detection and should fix the related pull requests too.

Closes: #5
Related: #6, #7 