### PR TITLE
Fixed a small typo in README.org.

### DIFF
--- a/README.org
+++ b/README.org
@@ -10,7 +10,7 @@ For input access (decompression), the compression format is auto-detected, and m
 
 For output access (compression), the only parameter exposed by this API is the compression level.
 
-To add zstr within a CMake project, include this directory within your CMakeLists.txxt: 'add_subdirectory(zstr)' and include zstr for each required target when specifiying target_link_libraries. 
+To add zstr within a CMake project, include this directory within your CMakeLists.txt: 'add_subdirectory(zstr)' and include zstr for each required target when specifiying target_link_libraries. 
   For cmake versions < 3.13, you will also need to 'include_directories(zstr/src)'
 
 Alternatives to this library include:
@@ -58,4 +58,3 @@ For all stream objects, the =badbit= of their expection mask is turned on in ord
 **** License
 
 Released under the [[file:LICENSE][MIT license]].
-


### PR DESCRIPTION
Changed a '.txxt' extension to '.txt' and removed an extra blank line at the end of the file.