### PR TITLE
Improve CMakeLists and add CMake instructions in README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,15 +2,25 @@ cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(zstr)
 
 if(${CMAKE_VERSION} VERSION_LESS 3.13)
-  message(WARNING "Interface libraries are not well supported before cmake 3.13, you will need to include within the parent CMakeLists.txt: INCLUDE_DIRECTORIES(zstr/src)") 
+  message(WARNING
+    "Interface libraries are not well supported before cmake 3.13, you will "
+    "need to manually add 'zstr/src' to your include directories. The simplest "
+    "way is to add the following line within the parent CMakeLists.txt:\n"
+    "include_directories(zstr/src)"
+  )
 endif()
 
 # zlib is required
-find_package(ZLIB 1.2.3 REQUIRED)
+find_package(ZLIB 1.2.3 REQUIRED) # defines imported target ZLIB::ZLIB
+message(STATUS "zstr - found ZLIB (version: ${ZLIB_VERSION_STRING})")
 
 add_library(zstr INTERFACE)
 target_include_directories(zstr INTERFACE src ${ZLIB_INCLUDE_DIRS})
 target_link_libraries(zstr INTERFACE ${ZLIB_LIBRARIES})
 
-message(STATUS "Adding zstr and ZLIB for ${PROJECT_NAME}: includes: ${CMAKE_CURRENT_SOURCE_DIR}/src ${ZLIB_INCLUDE_DIRS} and libraries: ${ZLIB_LIBRARIES}")
 
+message(STATUS
+  "zstr - added INTERFACE target 'zstr'
+          includes: ${PROJECT_SOURCE_DIR}/src  ${ZLIB_INCLUDE_DIRS}
+          libraries: ${ZLIB_LIBRARIES}"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,9 @@ endif()
 
 if(${CMAKE_VERSION} VERSION_LESS 3.13)
   message(WARNING
-    "Interface libraries are not well supported before cmake 3.13, you will "
-    "need to manually add 'zstr/src' to your include directories. The simplest "
-    "way is to add the following line within the parent CMakeLists.txt:\n"
-    "include_directories(zstr/src)"
+    "Interface library targets are not well supported before cmake 3.13  .... "
+    "You may need to add \${ZSTR_INCLUDE_DIRS} to your include directories\n"
+    "target_include_directories(YourTarget PRIVATE \${ZSTR_INCLUDE_DIRS}) "
   )
 endif()
 
@@ -21,9 +20,13 @@ message(STATUS "zstr - found ZLIB (version: ${ZLIB_VERSION_STRING})")
 
 add_library(zstr INTERFACE)
 add_library(zstr::zstr ALIAS zstr)
-target_include_directories(zstr INTERFACE src)
+target_include_directories(zstr INTERFACE "${PROJECT_SOURCE_DIR}/src")
 target_link_libraries(zstr INTERFACE ZLIB::ZLIB)
 target_compile_features(zstr INTERFACE cxx_std_11) # require c++11 flag
+
+# NOTE: these vars are mostly useful to people using cmake < 3.13
+set(ZSTR_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src;${ZLIB_INCLUDE_DIRS}" CACHE PATH "" FORCE)
+set(ZSTR_LIBRARIES "${ZLIB_LIBRARIES}" CACHE PATH "" FORCE)
 
 
 message(STATUS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
-project(zstr)
+
+project(zstr LANGUAGES CXX)
+
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.12)
+  cmake_policy(SET CMP0074 NEW) # find_package uses <PackageName>_ROOT variables
+endif()
 
 if(${CMAKE_VERSION} VERSION_LESS 3.13)
   message(WARNING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,10 @@ find_package(ZLIB 1.2.3 REQUIRED) # defines imported target ZLIB::ZLIB
 message(STATUS "zstr - found ZLIB (version: ${ZLIB_VERSION_STRING})")
 
 add_library(zstr INTERFACE)
-target_include_directories(zstr INTERFACE src ${ZLIB_INCLUDE_DIRS})
-target_link_libraries(zstr INTERFACE ${ZLIB_LIBRARIES})
+add_library(zstr::zstr ALIAS zstr)
+target_include_directories(zstr INTERFACE src)
+target_link_libraries(zstr INTERFACE ZLIB::ZLIB)
+target_compile_features(zstr INTERFACE cxx_std_11) # require c++11 flag
 
 
 message(STATUS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,23 +14,33 @@ if(${CMAKE_VERSION} VERSION_LESS 3.13)
   )
 endif()
 
-# zlib is required
+# -- locate zlib
+
 find_package(ZLIB 1.2.3 REQUIRED) # defines imported target ZLIB::ZLIB
 message(STATUS "zstr - found ZLIB (version: ${ZLIB_VERSION_STRING})")
 
+# -- add target
+
 add_library(zstr INTERFACE)
 add_library(zstr::zstr ALIAS zstr)
+
+# -- set target properties
+
 target_include_directories(zstr INTERFACE "${PROJECT_SOURCE_DIR}/src")
 target_link_libraries(zstr INTERFACE ZLIB::ZLIB)
 target_compile_features(zstr INTERFACE cxx_std_11) # require c++11 flag
+
+# -- set cache varibles
 
 # NOTE: these vars are mostly useful to people using cmake < 3.13
 set(ZSTR_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src;${ZLIB_INCLUDE_DIRS}" CACHE PATH "" FORCE)
 set(ZSTR_LIBRARIES "${ZLIB_LIBRARIES}" CACHE PATH "" FORCE)
 
+# -- print target summary
 
 message(STATUS
-  "zstr - added INTERFACE target 'zstr'
-          includes: ${PROJECT_SOURCE_DIR}/src  ${ZLIB_INCLUDE_DIRS}
-          libraries: ${ZLIB_LIBRARIES}"
+  "zstr - added INTERFACE target 'zstr::zstr'
+          includes : ${ZSTR_INCLUDE_DIRS}
+          libraries: ZLIB::ZLIB
+          features : cxx_std_11"
 )

--- a/README.org
+++ b/README.org
@@ -52,13 +52,11 @@ The package provides 6 classes for accessing ZLib streams:
 
 For all stream objects, the =badbit= of their expection mask is turned on in order to propagate exceptions.
 
-**** CMake projects
+**** CMake
 
-There are two simple ways to add zstr to a CMake project
+There are two simple ways to add zstr to a CMake project.
 
-1. Add zstr to your project as a subdirectory and link to the =zstr::zstr= target as needed.
-
-  /NOTE: This method is supported on versions of CMake newer than 3.10/
+Method 1. Add zstr as a subdirectory and link to the =zstr::zstr= target
 
   #+BEGIN_SRC cmake
     add_subdirectory(zstr) # defines INTERFACE target 'zstr::zstr'
@@ -66,10 +64,10 @@ There are two simple ways to add zstr to a CMake project
     add_executable(YourTarget main.cpp)
     target_link_libraries(YourTarget PRIVATE zstr::zstr)
     # if using cmake < 3.13 you may also need the following line
-    # target_include_directories(YourTarget PRIVATE zstr/src)
+    # target_include_directories(YourTarget PRIVATE ${ZSTR_INCLUDE_DIRS})
   #+END_SRC
 
-2. Fetch a copy of zstr from an external git repository at configure time
+Method 2. Fetch a copy of zstr from an external repository and link to the =zstr::zstr= target
 
   /NOTE: The FetchContent functions shown here were introduced in CMake 3.14/
 

--- a/README.org
+++ b/README.org
@@ -10,9 +10,6 @@ For input access (decompression), the compression format is auto-detected, and m
 
 For output access (compression), the only parameter exposed by this API is the compression level.
 
-To add zstr within a CMake project, include this directory within your CMakeLists.txt: 'add_subdirectory(zstr)' and include zstr for each required target when specifiying target_link_libraries. 
-  For cmake versions < 3.13, you will also need to 'include_directories(zstr/src)'
-
 Alternatives to this library include:
 
 - The original [[http://www.zlib.net/][ZLib]], through its [[http://www.zlib.net/manual.html][C API]]. This does not interact nicely with C++ iostreams.
@@ -54,6 +51,39 @@ The package provides 6 classes for accessing ZLib streams:
 - =zstr::ofstream= is a wrapper for a =zstr::ostreambuf= that accesses an /internal/ =std::ofstream=. This can be used to open a file and write compressed data to it.
 
 For all stream objects, the =badbit= of their expection mask is turned on in order to propagate exceptions.
+
+**** CMake projects
+
+There are two simple ways to add zstr to a CMake project
+
+1. Add zstr to your project as a subdirectory and link to the =zstr::zstr= target as needed.
+
+  /NOTE: This method is supported on versions of CMake newer than 3.10/
+
+  #+BEGIN_SRC cmake
+    add_subdirectory(zstr) # defines INTERFACE target 'zstr::zstr'
+
+    add_executable(YourTarget main.cpp)
+    target_link_libraries(YourTarget PRIVATE zstr::zstr)
+    # if using cmake < 3.13 you may also need the following line
+    # target_include_directories(YourTarget PRIVATE zstr/src)
+  #+END_SRC
+
+2. Fetch a copy of zstr from an external git repository at configure time
+
+  /NOTE: The FetchContent functions shown here were introduced in CMake 3.14/
+
+  #+BEGIN_SRC cmake
+    include(FetchContent)
+    FetchContent_Declare(ZStrGitRepo
+      GIT_REPOSITORY    "https://github.com/mateidavid/zstr" # can also be a local filesystem path!
+      GIT_TAG           "master"
+    )
+    FetchContent_MakeAvailable(ZStrGitRepo) # defines INTERFACE target 'zstr::zstr'
+
+    add_executable(YourTarget main.cpp)
+    target_link_libraries(YourTarget PRIVATE zstr::zstr)
+  #+END_SRC
 
 **** License
 

--- a/README.org
+++ b/README.org
@@ -54,7 +54,7 @@ For all stream objects, the =badbit= of their expection mask is turned on in ord
 
 **** CMake
 
-There are two simple ways to add zstr to a CMake project.
+There are three simple ways to add zstr to a CMake project.
 
 Method 1. Add zstr as a subdirectory and link to the =zstr::zstr= target
 
@@ -81,6 +81,17 @@ Method 2. Fetch a copy of zstr from an external repository and link to the =zstr
 
     add_executable(YourTarget main.cpp)
     target_link_libraries(YourTarget PRIVATE zstr::zstr)
+  #+END_SRC
+
+Method 3. Add path containing 'zstr.hpp' to your target's include directories
+
+  /NOTE: With this method you're responsible for finding and linking to ZLIB !/
+
+  #+BEGIN_SRC cmake
+    find_package(ZLIB REQUIRED)
+    add_executable(YourTarget main.cpp)
+    target_link_libraries(YourTarget PRIVATE ZLIB::ZLIB)
+    target_include_directories(YourTarget PRIVATE /path/to/zstr/src)
   #+END_SRC
 
 **** License


### PR DESCRIPTION
I tidied up the CMakeLists file a bit!

Notable changes:
- Vastly improves the CMake instructions in the README
- Defines an ALIAS target `zstr::zstr` that users can optionally use to link against
- Explicitly sets the `CMP0074` policy to silence the annoying (and harmless) warning when ZLIB_ROOT is set by the user
- Sets `ZSTR_INCLUDE_DIRS` and `ZSTR_LIBRARIES` variables for people who are having troubles with cmake < 3.13
- Adds `cxx_std_11` as a compile feature to the zstr target