### PR TITLE
Add ostream and istream constructor parameters when using std::streambuf

### DIFF
--- a/src/zstr.hpp
+++ b/src/zstr.hpp
@@ -380,8 +380,9 @@ public:
     {
         exceptions(std::ios_base::badbit);
     }
-    explicit istream(std::streambuf * sbuf_p)
-        : std::istream(new istreambuf(sbuf_p))
+    explicit istream(std::streambuf * sbuf_p,
+            std::size_t _buff_size = default_buff_size, bool _auto_detect = true, int _window_bits = 0)
+        : std::istream(new istreambuf(sbuf_p, _buff_size, _auto_detect, _window_bits))
     {
         exceptions(std::ios_base::badbit);
     }
@@ -401,8 +402,9 @@ public:
     {
         exceptions(std::ios_base::badbit);
     }
-    explicit ostream(std::streambuf * sbuf_p)
-        : std::ostream(new ostreambuf(sbuf_p))
+    explicit ostream(std::streambuf * sbuf_p,
+            std::size_t _buff_size = default_buff_size, int _level = Z_DEFAULT_COMPRESSION, int _window_bits = 0)
+        : std::ostream(new ostreambuf(sbuf_p, _buff_size, _level, _window_bits))
     {
         exceptions(std::ios_base::badbit);
     }


### PR DESCRIPTION
It's quite a pain to specify the use of zlib and gzip when using boost::asio::streambuf